### PR TITLE
Working around the hash issue with skip_verify

### DIFF
--- a/kafka/install/apache/init.sls
+++ b/kafka/install/apache/init.sls
@@ -21,6 +21,7 @@ kafka-pkg-setup:
     - source_hash: {{ source_hash }}
     - user: kafka
     - group: kafka
+    - skip_verify: True
   file.symlink:
     - name: {{ kafka.prefix }}/kafka
     - target: {{ kafka.prefix }}/kafka_{{ kafka.scala_version }}-{{ kafka.version }}


### PR DESCRIPTION
We keep getting a hash error because the command used to get the hash is failing. This is a workaround for now. 